### PR TITLE
Remove the dot in require statement.

### DIFF
--- a/src/Icons.php
+++ b/src/Icons.php
@@ -2,7 +2,7 @@
 
 namespace Feather;
 
-require __DIR__ . './defaultAttributes.php';
+require __DIR__ . '/defaultAttributes.php';
 
 use Feather\DEFAULT_ATTRIBUTES;
 


### PR DESCRIPTION
In src/Icons.php on line 5, in the require statement there's a dot that's causing it not to work (at least not on my setup). Removing this dot fixes it. Here's an error log:
````
2018/12/25 11:06:32 [error] 767#767: *609 FastCGI sent in stderr: "PHP message: PHP Warning:  Uncaught ErrorException: require(projectpath/vendor/pixelrobin/php-feather/src./defaultAttributes.php): failed to open stream: No such file or directory in projectpath/vendor/pixelrobin/php-feather/src/Icons.php:5
````
I was trying to use it in my Laravel project, it works now when I remove the dot. Otherwise, good job man.