### PR TITLE
Add icon aliases

### DIFF
--- a/src/Exception/AliasDefinedException.php
+++ b/src/Exception/AliasDefinedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Feather\Exception;
+
+class AliasDefinedException extends \Exception
+{
+
+}

--- a/src/IconManager.php
+++ b/src/IconManager.php
@@ -2,6 +2,7 @@
 
 namespace Feather;
 
+use Feather\Exception\AliasDefinedException;
 use Feather\Exception\IconNotFoundException;
 
 class IconManager
@@ -9,6 +10,8 @@ class IconManager
     use SvgAttributesTrait;
 
     private $icons;
+
+    private $aliases = [];
 
     public function __construct()
     {
@@ -23,10 +26,37 @@ class IconManager
 
     public function getIcon(string $name, array $attributes = []): Icon
     {
+        $name = $this->normalizeIconName($name);
+
         if (!isset($this->icons[$name])) {
             throw new IconNotFoundException(\sprintf('Icon `%s` not found', $name));
         }
 
         return new Icon($name, \array_merge($this->attributes, $attributes), $this->icons[$name]);
+    }
+
+    public function addAlias(string $alias, string $iconName): self
+    {
+        if (isset($this->aliases[$alias])) {
+            throw new AliasDefinedException(\sprintf('Alias `%s` already defined', $alias));
+        }
+
+        if (!isset($this->icons[$iconName])) {
+            throw new IconNotFoundException(\sprintf('Icon `%s` not found', $iconName));
+        }
+
+        $this->aliases[$alias] = $iconName;
+
+        return $this;
+    }
+
+    public function getIconAliases(): array
+    {
+        return $this->aliases;
+    }
+
+    private function normalizeIconName(string $name): string
+    {
+        return $this->aliases[$name] ?? $name;
     }
 }


### PR DESCRIPTION
Add icon aliases. This allows setting an alias for an icon you'd like to use. Closes #29

This allows adding aliases to the icon manager to ask for an icon for a particular context, rather than by the name of the icon itself. One example of when I would use this is for using the `x` icon. If I did want to update it, trying to find `x` in a codebase would be much more difficult than something like `close` or `close-dialog`.