### PR TITLE
Remove php 7.3 support and add 8.1 to testing

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: ['7.3', '7.4', '8.0']
+                php: ['7.4', '8.0', '8.1']
 
         steps:
             -   name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3"
+        "php": ">=7.4"
     },
     "require-dev": {
         "ext-dom": "*",


### PR DESCRIPTION
Goal: Only support php versions that are currently supported.

7.3 is about to go EOL (Dec 6). Since we're about to release a new major version, it doesn't make sense to ship with 7.3 support for less than 1 month